### PR TITLE
Test for Python syntax errors and undefined names

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,10 @@ skip_missing_interpreters = true
 
 [testenv]
 deps =
+    flake8
     pytest
     nbval
     jupyter
 commands =
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     pytest --nbval notebooks


### PR DESCRIPTION
http://flake8.pycqa.org will flag the build if there are Python syntax errors or undefined names.

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree