### PR TITLE
missing magic

### DIFF
--- a/notebooks/beginner/exercises/testing1_exercise.ipynb
+++ b/notebooks/beginner/exercises/testing1_exercise.ipynb
@@ -11,8 +11,9 @@
     "!{sys.executable} -m pip install pytest\n",
     "!{sys.executable} -m pip install ipytest\n",
     "\n",
-    "import ipytest.magics\n",
     "import pytest\n",
+    "import ipytest\n",
+    "ipytest.autoconfig()\n",
     "\n",
     "__file__ = 'testing1_exercise.ipynb'"
    ]
@@ -72,9 +73,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/beginner/exercises/testing2_exercise.ipynb
+++ b/notebooks/beginner/exercises/testing2_exercise.ipynb
@@ -11,8 +11,9 @@
     "!{sys.executable} -m pip install pytest\n",
     "!{sys.executable} -m pip install ipytest\n",
     "\n",
-    "import ipytest.magics\n",
     "import pytest\n",
+    "import ipytest\n",
+    "ipytest.autoconfig()\n",
     "\n",
     "__file__ = 'testing2_exercise.ipynb'"
    ]
@@ -192,9 +193,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/beginner/notebooks/testing1.ipynb
+++ b/notebooks/beginner/notebooks/testing1.ipynb
@@ -57,8 +57,10 @@
     "!{sys.executable} -m pip install pytest\n",
     "!{sys.executable} -m pip install ipytest\n",
     "\n",
-    "import ipytest.magics\n",
+    "import ipytest\n",
     "import pytest\n",
+    "ipytest.autoconfig()\n",
+    "\n",
     "\n",
     "# Filename has to be set explicitly for ipytest \n",
     "__file__ = 'testing1.ipynb'"
@@ -130,9 +132,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "cs6010",
    "language": "python",
-   "name": "python3"
+   "name": "cs6010"
   },
   "language_info": {
    "codemirror_mode": {
@@ -144,9 +146,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/beginner/notebooks/testing2.ipynb
+++ b/notebooks/beginner/notebooks/testing2.ipynb
@@ -19,8 +19,10 @@
     "!{sys.executable} -m pip install pytest\n",
     "!{sys.executable} -m pip install ipytest\n",
     "\n",
-    "import ipytest.magics\n",
+    "import ipytest\n",
     "import pytest\n",
+    "ipytest.autoconfig()\n",
+    "\n",
     "__file__ = 'testing2.ipynb'"
    ]
   },
@@ -193,9 +195,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/intermediate/notebooks/pytest_fixtures.ipynb
+++ b/notebooks/intermediate/notebooks/pytest_fixtures.ipynb
@@ -26,7 +26,8 @@
     "!{sys.executable} -m pip install pytest 'ipytest>=0.3.0'\n",
     "\n",
     "import pytest\n",
-    "from ipytest import magics, clean_tests\n",
+    "from ipytest import autoconfig, clean_tests\n",
+    "autoconfig()\n",
     "__file__ = 'pytest_fixtures.ipynb'"
    ]
   },
@@ -354,13 +355,20 @@
     "def test_2():\n",
     "    pass"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "cs6010",
    "language": "python",
-   "name": "python3"
+   "name": "cs6010"
   },
   "language_info": {
    "codemirror_mode": {
@@ -372,9 +380,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
`ipytest.magics` command does not work with new version of ipytest. Now it is replaced with the working version